### PR TITLE
Remove - References to Engage project

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ If you want to change the source Kentico Cloud project, follow these steps:
 3. Copy your Project ID.
 4. Open `app\Providers\AppServiceProvider.php` file in the sample application folder.
 5. Find `new DeliveryClient('975bf280-fd91-488c-994c-2f04416e5ee3');` and replace guid with your Project ID.
-6. In the same file, find `share('engage_project_id', 'ace71be0-4898-4e7f-b0b6-f416080e5b8b')` and replace it with your Project ID as well.
-7. Save the file.
+6. Save the file.
 
 When you run the sample application now, content is retrieved from your project.
 
@@ -45,28 +44,10 @@ For more info about the API, see the [API reference](https://developer.kenticocl
 
 You can find the Delivery and other SDKs at https://github.com/Kentico.
 
-## Tracking visitors and their activity
-
-By default you can see sample visitor data in Kentico Cloud, even if you already feed the single-page application with your own content. Tracking real visitors needs to be set up separately and here's how to.
-
-Tracking via tracking code on all public pages is enabled by default and can be configured in files `app\Providers\AppServiceProvider.php` and `resources\views\layouts\app.blade.php`.
-
-If you want to update project that will track events from your pages, you have to replace guid in `app\Providers\AppServiceProvider.php` on line containing `share('engage_project_id', 'guid')` with your Project ID.
-
-To remove tracking code altogether, remove following code from `resources\views\layouts\app.blade.php`:
-
-```html
-    <script type="text/javascript">
-        !function(){var a='https://engage-ket.kenticocloud.com/js',b=document,c=b.createElement('script'),d=b.getElementsByTagName('script')[0];c.type='text/javascript',c.async=!0,c.defer=!0,c.src=a+'?d='+document.domain,d.parentNode.insertBefore(c,d)}(),window.ket=window.ket||function(){(ket.q=ket.q||[]).push(arguments)};
-        ket('start', '{{ $engage_project_id }}');
-    </script>
-```
-
-When you have tracking enabled and visit any of publicly facing pages, you should be able to see your visit in Analytics of Kentico Cloud. You can also create a new dynamic segment of people who did the custom activity you created and see that the segment is not empty. It should contain you as anonymous visitor. You can learn more about creating segments with Kentico Cloud in the [documentation](https://help.kenticocloud.com/contact-tracking-and-content-personalization/segments/creating-segments-of-your-visitors).
-
 ### Known issues
 
 #### Sunra's HTML DOM parser
+
 When using this sample application with some versions of PHP (reproduced on v7.1.13, 7.1.18 and 7.2), one of the dependencies ([sunra/php-simple-html-dom-parser](https://github.com/sunra/php-simple-html-dom-parser/)) tends to get stuck in an endless loop of calls to its own destructor. We worked-around this issue by renaming destructors in fetched dependencies every time they are changed. For futher reference, please see the [issue in package's repository repository](https://github.com/sunra/php-simple-html-dom-parser/issues/60).
 
 ## Author

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,8 +21,6 @@ class AppServiceProvider extends ServiceProvider
 
         view()->share('company_address', $homeData->contact);
 
-        view()->share('engage_project_id', 'ace71be0-4898-4e7f-b0b6-f416080e5b8b');
-
         view()->share('google_maps_key', 'AIzaSyAVOq4C-rf7JVeHt6ws9vsf-KHIRpueASg');
     }
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -104,10 +104,5 @@
     <script src="{{ asset('js/bootstrap.min.js') }}"></script>
 
     @yield('scripts')
-
-    <script type="text/javascript">
-        !function(){var a='https://engage-ket.kenticocloud.com/js',b=document,c=b.createElement('script'),d=b.getElementsByTagName('script')[0];c.type='text/javascript',c.async=!0,c.defer=!0,c.src=a+'?d='+document.domain,d.parentNode.insertBefore(c,d)}(),window.ket=window.ket||function(){(ket.q=ket.q||[]).push(arguments)};
-        ket('start', '{{ $engage_project_id }}');
-    </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation

Since there is no more Engage, I removed references to Engage's tracking API (tracking code in base template) + Engage related settings and updated README not to consider it.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [x] Docu has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

* Application should still work after `composer update` && `php artisan serve`
* No errors should be logged to JS console relevant to loading/referencing tracking code.