### PR TITLE
Add removing of the destruct method

### DIFF
--- a/Installer.php
+++ b/Installer.php
@@ -1,4 +1,12 @@
 <?php 
+/**
+ * When serving KenticoCloud PHP Sample Application using `php artisan serve`
+ * command, the combination of Laravel (5.3+) and of a package
+ * kub-at/php-simple-html-dom-parser exhibits an issue where laravel gets stuck
+ * in an infinite loop of calls.
+ */
+define("PACKAGE_TO_FIX" , "kub-at/php-simple-html-dom-parser");
+define("MINIMUM_REQUIRED_LINES_IN_FILE", 1000);
 
 /**
  * Recursively retrieves nested files with .php extension from given directory.
@@ -37,4 +45,54 @@ function countFileLines($file)
     $fileAPI->seek(PHP_INT_MAX);
     return $fileAPI->key() + 1; 
 }
+
+
+/**
+ * Searches file for occurrence of 'function __destruct' and replaces it with 
+ * improbably manually selectable name. This prevents combination of Laravel
+ * and kub-at/php-simple-html-dom-parser-package to become stuck in an endless
+ * loop of __destruct calls by renaming __destruct function. 
+ */
+function removeDestructorFunction($file)
+{
+    try {
+        $fc = file_get_contents($file);
+        if (empty($fc)){
+            showErrorFixingMessage();
+            return;
+        }
+        $fc = str_replace('function __destruct', 'function __m3TlMNSgdA__CS2yxVRIAO_destructor_removed', $fc);
+        file_put_contents($file, $fc);
+    } catch (Exception $e) {
+        showErrorFixingMessage();
+    }
+}
+
+
+function showErrorFixingMessage()
+{
+    echo "=====================================================================";
+    echo "ERROR: Fixing kub-at/php-simple-html-dom-parser package. " . PHP_EOL;
+    echo "Please manually modify file: " . PHP_EOL;
+    echo "$file" . PHP_EOL ; 
+    echo "And rename all occurences of __destruct() function." . PHP_EOL;
+    echo "=====================================================================";
+}
+
+
+echo "Installer will now remove destructors from kub-AT/php-simple-html-dom-parser package." . PHP_EOL;
+foreach (getAllPhpFiles('vendor' . DIRECTORY_SEPARATOR . PACKAGE_TO_FIX) as $file)
+{
+    // Lets base this on reasonable thought that HTML parser will never fit 
+    // into less than 1000 lines of code and ignore all files that contain
+    // less lines of code. Note that this approach assumes very specific
+    // kub-at/php-simple-html-dom-parser package structure and will not work
+    // out of the box for other packages.
+    if (countFileLines($file) > MINIMUM_REQUIRED_LINES_IN_FILE)
+    {
+        echo "Updating: " . basename($file) . PHP_EOL;
+        removeDestructorFunction($file);
+    }
+}
+echo "Done."
 ?>

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ For more info about the API, see the [API reference](https://developer.kenticocl
 
 You can find the Delivery and other SDKs at [Kentico Github Organization](https://github.com/Kentico).
 
+### Known issues	
+
+#### Kub-AT's HTML DOM parser	
+
+When using this sample application with some versions of PHP (reproduced on v 7.3.7), one of the dependencies ([kub-AT/php-simple-html-dom-parser](https://github.com/kub-AT/php-simple-html-dom-parser/)) tends to get stuck in an endless loop of calls to its own destructor. We worked-around this issue by renaming destructors in fetched dependencies every time they are changed. For futher reference, please see the [issue in package's repository repository](https://github.com/sunra/php-simple-html-dom-parser/issues/60) and (original package issue)[https://sourceforge.net/p/simplehtmldom/support-requests/49/].
+
 ## Feedback & Contributing
 
 Check out the [contributing](https://github.com/Kentico/kontent-sample-app-php/blob/master/CONTRIBUTING.md) page to see the best places to file issues, start discussions, and begin contributing.


### PR DESCRIPTION
### Motivation

As a part of #10 - the workaround about the destruct was removed, because of [changing the parser in the PHP SDK](https://github.com/Kentico/kontent-delivery-sdk-php/pull/80). 
But the same issue appeared in the new parser as well.

Related to #11 

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
