### PR TITLE
Update instructions on running the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Once these prerequisites are met, you can run the application as follows:
 1. Clone this repository.
 1. In your command line, navigate to the project folder.
 1. Run `composer install` to install dependencies.
+1. (Optional) Run `composer run prepare-environment` to create a sample [Laravel environment file](https://laravel.com/docs/5.5/configuration#environment-configuration).
 1. Run `php artisan serve` to run the sample app.
 
 The app is now running locally at [`127.0.0.1:8000`](127.0.0.1:8000) (default) and you can open it in your browser.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Once these prerequisites are met, you can run the application as follows:
 1. Clone this repository.
 1. In your command line, navigate to the project folder.
 1. Run `composer install` to install dependencies.
-1. (Optional) Run `composer run prepare-environment` to create a sample [Laravel environment file](https://laravel.com/docs/5.5/configuration#environment-configuration).
+1. (Optional) Run `composer run prepare-environment` to create a sample [Laravel environment file](https://laravel.com/docs/6.x/configuration#environment-configuration).
 1. Run `php artisan serve` to run the sample app.
 
 The app is now running locally at [`127.0.0.1:8000`](127.0.0.1:8000) (default) and you can open it in your browser.

--- a/README.md
+++ b/README.md
@@ -2,38 +2,49 @@
 
 [![Stack Overflow](https://img.shields.io/badge/Stack%20Overflow-ASK%20NOW-FE7A16.svg?logo=stackoverflow&logoColor=white)](https://stackoverflow.com/tags/kentico-kontent)
 
-This is a sample website written in PHP7 using [Laravel](https://laravel.com) framework and [Kentico Kontent Delivery SDK for PHP](https://github.com/Kentico/kontent-delivery-sdk-php). You can register your account for free at [https://app.kontent.ai](https://app.kontent.ai).
+This is a sample website written in PHP 7 using [Laravel](https://laravel.com) framework and [Kentico Kontent Delivery SDK for PHP](https://github.com/Kentico/kontent-delivery-sdk-php). You can register your Kontent account for free at [https://app.kontent.ai](https://app.kontent.ai).
 
 ## Application setup
 
-There should be PHP7.2 and higher and composer installed in your environment. Once these prerequisites are met, you run the application as follows:
+Before you can run the app, make sure your environment is set up correctly with [PHP 7+](https://www.php.net/downloads.php) and the [Composer](https://getcomposer.org/) package manager installed.
+
+* For Windows, see how to [configure Visual Studio Code for PHP pevelopment](https://github.com/Kentico/kontent-delivery-sdk-php/wiki/Developing-PHP-in-Visual-Studio-Code-for-Dummies).
+* For Linux distrubutions, see how to [configure PHP Storm for PHP development](https://github.com/Kentico/kontent-delivery-sdk-php/wiki/Configuring-PHP-Storm-on-Linux).
+
+Once these prerequisites are met, you can run the application as follows:
 
 1. Clone this repository.
-2. `cd` in the project folder and run `composer update` and `php artisan serve` commands.
-3. Access `127.0.0.1:8000` (default) to browse the application.
+1. In your command line, navigate to the project folder.
+1. Run `composer install` to install dependencies.
+1. Run `php artisan serve` to run the sample app.
 
-Alternatively you can also deploy your application to your apache server just by cloning the repository, running composer update and accessing corresponding address on your server.
+The app is now running locally at [`127.0.0.1:8000`](127.0.0.1:8000) (default) and you can open it in your browser.
+
+Alternatively, you can also deploy your application to your Apache server  by cloning the repository, running `composer install`, and accessing corresponding address on your server.
 
 ### Connecting your project
 
 This sample website displays content from a Sample Project that demonstrates Kentico Kontent features and best practices. This fully featured project contains marketing content for Dancing Goat – an imaginary chain of coffee shops. By default, this sample website uses a shared project where the content remains constant for everyone.
 
-You can change the source Kentico Kontent project to your own project to be able to change the content. If you don't have your own Sample Project, any admin of a Kentico Kontent subscription [can generate one](https://app.kontent.ai/sample-project-generator). When you have a Sample Project, follow these steps to connect it to this sample website:
+You can change the source Kentico Kontent project to your own project to be able to change the content. If you don't have your own Sample Project, any admin of a Kentico Kontent subscription [can generate one](https://docs.kontent.ai/tutorials/set-up-projects/manage-projects/managing-projects#a-creating-a-sample-project).
+
+When you have a Sample Project, follow these steps to connect it to this sample app:
 
 1. In Kentico Kontent, choose Project settings from the app menu.
-2. Under Development, choose API keys.
-3. Copy your Project ID.
-4. Open `app\Providers\AppServiceProvider.php` file in the sample application folder.
-5. Find `new DeliveryClient('975bf280-fd91-488c-994c-2f04416e5ee3');` and replace guid with your Project ID.
-6. Save the file.
+1. Under Development, choose API keys.
+1. Copy your Project ID.
+1. In the sample app folder, open the `app\Providers\AppServiceProvider.php` file.
+1. At the bottom, find the line that ends with `new DeliveryClient('975bf280-fd91-488c-994c-2f04416e5ee3');`.
+1. Replace `975bf280-fd91-488c-994c-2f04416e5ee3` with the ID of your Sample Project.
+1. Save the file.
 
 Now when you run the sample application, content is retrieved from your project.
 
 ## Content administration
 
 1. Navigate to https://app.kontent.ai in your browser.
-2. Sign in with your credentials.
-3. Manage content in the content administration interface of your sample project.
+1. Sign in with your credentials.
+1. Manage content in the content administration interface of your sample project.
 
 You can learn more about content editing with Kentico Kontent in the documentation.
 
@@ -44,7 +55,7 @@ You can retrieve content either through the Kentico Kontent Delivery SDKs or the
 * For published content, use `https://deliver.kontent.ai/PROJECT_ID/items`.
 * For unpublished content, use `https://preview-deliver.kontent.ai/PROJECT_ID/items`.
 
-For more info about the API, see the [API reference](https://developer.kenticocloud.com/reference).
+For more info about the API, see the [API reference](https://docs.kontent.ai/reference/kentico-kontent-apis-overview).
 
 You can find the Delivery and other SDKs at [Kentico Github Organization](https://github.com/Kentico).
 
@@ -57,14 +68,6 @@ When using this sample application with some versions of PHP (reproduced on v 7.
 ## Feedback & Contributing
 
 Check out the [contributing](https://github.com/Kentico/kontent-sample-app-php/blob/master/CONTRIBUTING.md) page to see the best places to file issues, start discussions, and begin contributing.
-
-### Developing on Windows
-
-Have a look at our cool [tutorial](https://github.com/Kentico/kontent-delivery-sdk-php/wiki/Developing-PHP-in-Visual-Studio-Code-for-Dummies) on developing PHP on Windows with Visual Studio Code!
-
-### Developing on Linux
-
-Do you prefer penguins? Check out our [tutorials](https://github.com/Kentico/kontent-delivery-sdk-php/wiki/Configuring-PHP-Storm-on-Linux) on developing PHP on Linux with PhpStorm!
 
 ## Author
 


### PR DESCRIPTION
The instructions are incorrect and suggest using `composer update`, which actually breaks the app. Also, I've moved information about environment-specific guides to the top so that people can find them more easily.